### PR TITLE
Fix scikit-learn version notation

### DIFF
--- a/psap/classifier.py
+++ b/psap/classifier.py
@@ -1,17 +1,19 @@
+import datetime
 import os
+from pathlib import Path
+from random import sample
+
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-import matplotlib.pyplot as plt
-import datetime
-from random import sample
-from tqdm.notebook import tqdm
-from sklearn.preprocessing import MinMaxScaler
-from sklearn.ensemble import RandomForestClassifier
 import sklearn_json as skljson
-from pathlib import Path
-from .matrix import MakeMatrix
 from loguru import logger
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.preprocessing import MinMaxScaler
+from tqdm.notebook import tqdm
+
+from .matrix import MakeMatrix
 
 
 def annotate(df, labels=None):
@@ -150,8 +152,9 @@ def predict(
     try:
         logger.info("Loading model: {m}", m=model)
         clf = skljson.from_json(model)
-    except Exception:
+    except Exception as error:
         logger.error("classifier {mod} not found. Does the file exist?", mod=model)
+        logger.error(error)
     mat = export_matrix(prefix=prefix, fasta_path=path, out_path=out_dir)
     # Preprocessing
     data_ps = preprocess_and_scaledata(mat.df)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 import versioneer
 
 with open("README.rst") as readme_file:
@@ -11,7 +12,7 @@ with open("README.rst") as readme_file:
 requirements = [
     "pip==19.2.3",
     "wheel>=0.36.2",
-    "scikit-learn>=-0.21.3",
+    "scikit-learn~=0.21",
     "twine>=1.14.0",
     "pandas>=1.0.1",
     "biopython>=1.73",
@@ -24,7 +25,6 @@ requirements = [
     "loguru>=0.5.3",
     "black>=20.8b1",
 ]
-
 
 
 setup(


### PR DESCRIPTION
Hi, I'm using psap package for my project. Thank you for releasing the package.

Because setup.py use '>=' to specify scikit-learn version, currently it installs scikit-learn > 1.0.
scikit-learn > 1.0 does not have 'min_impurity_split' argument in RandomForestClassifier, PSAP will fail to load the serialized model in the package like [this stackoverflow entry](https://stackoverflow.com/questions/69520613/could-anyone-recommend-how-to-fix-this-error).

This PR fixes this issue by using '~=' version notation instead of '>='.  #27 should be solved with this change.